### PR TITLE
Fix broken live attribute

### DIFF
--- a/custom_components/youtube/sensor.py
+++ b/custom_components/youtube/sensor.py
@@ -119,7 +119,7 @@ async def is_live(channel_id, name, hass, session):
         async with async_timeout.timeout(10, loop=hass.loop):
             response = await session.get(url)
             info = await response.text()
-        if 'live-promo' in info:
+        if 'BADGE_STYLE_TYPE_LIVE_NOW' in info:
             returnvalue = True
             _LOGGER.debug('%s - Channel is live', name)
     except Exception as error:  # pylint: disable=broad-except


### PR DESCRIPTION
Closes #8

This should solve the non-working live attribute.  `live-promo` does not seem to be used any more, so check for live badge instead