### PR TITLE
fix live / stream / channel_image not working in some regions

### DIFF
--- a/custom_components/youtube/sensor.py
+++ b/custom_components/youtube/sensor.py
@@ -153,7 +153,7 @@ async def is_channel_live(url, name, hass, session):
     live = False
     try:
         async with async_timeout.timeout(10, loop=hass.loop):
-            response = await session.get(url)
+            response = await session.get(url, cookies=dict(CONSENT="YES+cb.0-0-p0.en+F+000", ANID="OPT_OUT"))
             info = await response.text()
         if '{"iconType":"LIVE"}' in info:
             live = True

--- a/custom_components/youtube/sensor.py
+++ b/custom_components/youtube/sensor.py
@@ -137,7 +137,7 @@ async def is_live(url, name, hass, session):
     stream = False
     try:
         async with async_timeout.timeout(10, loop=hass.loop):
-            response = await session.get(url, cookies=dict(CONSENT="YES+cb.0-0-p0.en+F+000", ANID="OPT_OUT"))
+            response = await session.get(url, cookies=dict(CONSENT="YES+cb"))
             info = await response.text()
         if 'isLiveBroadcast' in info:
             stream = True
@@ -153,7 +153,7 @@ async def is_channel_live(url, name, hass, session):
     live = False
     try:
         async with async_timeout.timeout(10, loop=hass.loop):
-            response = await session.get(url, cookies=dict(CONSENT="YES+cb.0-0-p0.en+F+000", ANID="OPT_OUT"))
+            response = await session.get(url, cookies=dict(CONSENT="YES+cb"))
             info = await response.text()
         if '{"iconType":"LIVE"}' in info:
             live = True

--- a/custom_components/youtube/sensor.py
+++ b/custom_components/youtube/sensor.py
@@ -137,7 +137,7 @@ async def is_live(url, name, hass, session):
     stream = False
     try:
         async with async_timeout.timeout(10, loop=hass.loop):
-            response = await session.get(url)
+            response = await session.get(url, cookies=dict(CONSENT="YES+cb.0-0-p0.en+F+000", ANID="OPT_OUT"))
             info = await response.text()
         if 'isLiveBroadcast' in info:
             stream = True


### PR DESCRIPTION
send cookie data to curcumvent YouTube's cookie consent screen.
Note that we are still NOT storing any returned cookie data

closes #31 