### PR TITLE
'device_state_attributes' is now deprecated

### DIFF
--- a/custom_components/youtube/sensor.py
+++ b/custom_components/youtube/sensor.py
@@ -118,7 +118,7 @@ class YoutubeSensor(Entity):
         return ICON
 
     @property
-    def device_state_attributes(self):
+    def extra_state_attributes(self):
         """Attributes."""
         return {'url': self.url,
                 'published': self.published,


### PR DESCRIPTION
'device_state_attributes' is deprecated starting with HA 2021.12.0
replaced 'device_state_attributes' with 'extra_state_attributes'