### PR TITLE
Fix for change in consent approve

### DIFF
--- a/custom_components/youtube/manifest.json
+++ b/custom_components/youtube/manifest.json
@@ -5,6 +5,6 @@
   "documentation": "https://github.com/custom-components/youtube",
   "dependencies": [],
   "codeowners": ["@pinkywafer"],
-  "requirements": [],
+  "requirements": ["beautifulsoup4"],
   "iot_class": "cloud_polling"
 }

--- a/custom_components/youtube/sensor.py
+++ b/custom_components/youtube/sensor.py
@@ -15,11 +15,10 @@ from homeassistant.helpers.entity import Entity
 from dateutil.parser import parse
 import re
 import html
+from bs4 import BeautifulSoup
 
 CONF_CHANNEL_ID = 'channel_id'
-
 ICON = 'mdi:youtube'
-
 BASE_URL = 'https://www.youtube.com/feeds/videos.xml?channel_id={}'
 CHANNEL_LIVE_URL = 'https://www.youtube.com/channel/{}'
 
@@ -34,19 +33,27 @@ async def async_setup_platform(
         hass, config, async_add_entities, discovery_info=None):  # pylint: disable=unused-argument
     """Setup sensor platform."""
     channel_id = config['channel_id']
+    _LOGGER.debug(f'Setting up {channel_id}')
     session = async_create_clientsession(hass)
     try:
         url = BASE_URL.format(channel_id)
         async with async_timeout.timeout(10):
             response = await session.get(url)
             info = await response.text()
-        name = info.split('<title>')[1].split('</')[0]
+            name = info.split('<title>')[1].split('</')[0]
     except Exception as error:  # pylint: disable=broad-except
-        _LOGGER.debug('Unable to set up - %s', error)
+        _LOGGER.error(f'Unable to set up {channel_id} - {error}')
         name = None
 
     if name is not None:
-        async_add_entities([YoutubeSensor(channel_id, name, session)], True)
+        sensor = YoutubeSensor(channel_id, name, session)
+        # Now make sure we approve consent
+        url = CHANNEL_LIVE_URL.format(channel_id)
+        async with async_timeout.timeout(10):
+            response = await session.get(url)
+            html = await response.text()
+            await sensor.approve_consent_if_needed(html)
+        async_add_entities([sensor], True)
 
 class YoutubeSensor(Entity):
     """YouTube Sensor class"""
@@ -70,7 +77,7 @@ class YoutubeSensor(Entity):
 
     async def async_update(self):
         """Update sensor."""
-        _LOGGER.debug('%s - Running update', self._name)
+        _LOGGER.debug(f'{self._name} - Running update')
         try:
             url = BASE_URL.format(self.channel_id)
             async with async_timeout.timeout(10):
@@ -83,9 +90,9 @@ class YoutubeSensor(Entity):
             title = info.split('<title>')[2].split('</')[0]
             url = info.split('<link rel="alternate" href="')[2].split('"/>')[0]
             if self.live or url != self.url:
-                self.stream, self.live, self.stream_start = await is_live(url, self._name, self.hass, self.session)
+                self.stream, self.live, self.stream_start = await self.is_live(url)
             else:
-                _LOGGER.debug('%s - Skipping live check', self._name)
+                _LOGGER.debug(f'{self._name} - Skipping live check')
             self.url = url
             self.content_id = url.split('?v=')[1]
             self.published = info.split('<published>')[2].split('</')[0]
@@ -94,11 +101,10 @@ class YoutubeSensor(Entity):
             self._state = html.unescape(title)
             self._image = thumbnail_url
             self.stars = info.split('<media:starRating count="')[1].split('"')[0]
-            self.views = info.split('<media:statistics views="')[1].split('"')[0]
-            url = CHANNEL_LIVE_URL.format(self.channel_id)
-            self.channel_live, self.channel_image = await is_channel_live(url, self.name, self.hass, self.session)
+            self.views = info.split('<media:statistics views="')[1].split('"')[0]            
+            self.channel_live, self.channel_image = await self.is_channel_live()
         except Exception as error:  # pylint: disable=broad-except
-            _LOGGER.debug('%s - Could not update - %s', self._name, error)
+            _LOGGER.debug(f'{self._name} - Could not update - {error}')
 
     @property
     def name(self):
@@ -139,37 +145,69 @@ class YoutubeSensor(Entity):
                 'channel_is_live': self.channel_live,
                 'channel_image': self.channel_image}
 
-async def is_live(url, name, hass, session):
-    """Return bool if video is stream and bool if video is live"""
-    live = False
-    stream = False
-    start = None
-    try:
-        async with async_timeout.timeout(10):
-            response = await session.get(url, cookies=dict(CONSENT="YES+cb"))
-            info = await response.text()
-        if 'isLiveBroadcast' in info:
-            stream = True
-            start = parse(info.split('startDate" content="')[1].split('"')[0])
-            if 'endDate' not in info:
-                live = True
-                _LOGGER.debug('%s - Latest Video is live', name)
-    except Exception as error:  # pylint: disable=broad-except
-        _LOGGER.debug('%s - Could not update - %s', name, error)
-    return stream, live, start
 
-async def is_channel_live(url, name, hass, session):
-    """Return bool if channel is live"""
-    live = False
-    try:
-        async with async_timeout.timeout(10):
-            response = await session.get(url, cookies=dict(CONSENT="YES+cb"))
-            info = await response.text()
-        if '{"iconType":"LIVE"}' in info:
-            live = True
-            _LOGGER.debug('%s - Channel is live', name)
-        regex = r"\"width\":48,\"height\":48},{\"url\":\"(.*?)\",\"width\":88,\"height\":88},{\"url\":"
-        channel_image = re.findall(regex, info, re.MULTILINE)[0].replace("=s88-c-k-c0x00ffffff-no-rj", "")
-    except Exception as error:  # pylint: disable=broad-except
-        _LOGGER.debug('%s - Could not update - %s', name, error)
-    return live, channel_image
+    async def is_live(self, url):
+        """Return bool if video is stream and bool if video is live"""
+        live = False
+        stream = False
+        start = None
+        try:
+            async with async_timeout.timeout(10):
+                response = await self.session.get(url)
+                html = await response.text()
+            if 'isLiveBroadcast' in html:
+                stream = True
+                start = parse(html.split('startDate" content="')[1].split('"')[0])
+                if 'endDate' not in html:
+                    live = True
+                    _LOGGER.debug(f'{self._name} - Latest Video is live')
+        except Exception as error:  # pylint: disable=broad-except
+            _LOGGER.debug(f'{self._name} - is_live(): Error {error}')
+        return stream, live, start
+
+
+    async def is_channel_live(self):
+        """Return bool if channel is live"""
+        live = False
+        channel_image = None
+        url = CHANNEL_LIVE_URL.format(self.channel_id)        
+        try:
+            async with async_timeout.timeout(10):
+                response = await self.session.get(url)
+                html = await response.text()
+            html = await self.approve_consent_if_needed(html)
+            if '{"iconType":"LIVE"}' in html:
+                live = True
+                _LOGGER.debug(f'{self._name} - Channel is live')
+            regex = r"\"width\":48,\"height\":48},{\"url\":\"(.*?)\",\"width\":88,\"height\":88},{\"url\":"
+            channel_image = re.findall(regex, html, re.MULTILINE)[0].replace("=s88-c-k-c0x00ffffff-no-rj", "")
+        except Exception as error:  # pylint: disable=broad-except
+            _LOGGER.debug(f'{self._name} - is_channel_live(): Error {error}')
+        return live, channel_image
+    
+    async def approve_consent_if_needed(self, html):
+        """Post a consent approve and returns the html"""
+        try:
+            if html.find('consent.youtube.com') == -1:
+                return html
+
+            _LOGGER.debug(f'{self._name} - Approving consent dialog')
+            soup = BeautifulSoup(html, 'html.parser')
+            form = soup.find('form')
+            if form is None:
+                _LOGGER.debug(f'{self._name[0:4096]} - {html}')
+                return html
+            consent_url = form.get('action')
+            form_values = {}
+            for input_element in form.find_all(['input']):
+                name = input_element.get('name')
+                value = input_element.get('value')
+                if name is not None:
+                    form_values[name] = value                
+            async with async_timeout.timeout(10):
+                response = await self.session.post(consent_url, data=form_values)    
+                result = await response.text()
+            return result
+        except Exception as error:  # pylint: disable=broad-except
+            _LOGGER.debug(f'{self._name} - approve_consent_if_needed(): Error {error}')
+        return html


### PR DESCRIPTION
My Youtube integration stopped working and I discovered it was because Youtube showed the Consent dialog and was waiting for the user to click a button. It seems adding the "CONSENT=YES+cb" cookie is no longer enough. 

I replaced the existing cookie handling by switching to`ClientSession` to handle requests instead. In the startup code I request the `CHANNEL_LIVE_URL` and check if returns a consent dialog. If so, I search for the first `form` tag found and POST the form. This returns the proper consent cookies, which are stored by the `session` for all later calls. 

